### PR TITLE
Build opencv libs with videoio module support (Linux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - run: ./build.sh emscripten
     - run: ./build.sh --simd emscripten
     - run: echo "Done!"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: build
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Set output
@@ -27,7 +27,7 @@ jobs:
           echo $RELEASE_VERSION
           echo ${{ steps.vars.outputs.tag }}
     - run: git submodule update --init
-    - run: sudo apt-get update && sudo apt install libjpeg-dev ninja-build
+    - run: sudo apt-get update && sudo apt install pcregrep libjpeg-dev ninja-build
     - run: ./build.sh linux
     - run: ./build.sh emscripten
     - run: ./build.sh emscripten-simd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         path: |
           packaging/opencv-4.7.0.zip
           packaging/opencv-js-4.7.0-emcc-3.1.26.zip
-          packaging/opencv-js-simd-4.7.0-emcc-3.1.26.zip
+          packaging/opencv-js-4.7.0-emcc-3.1.26-simd.zip
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -46,4 +46,4 @@ jobs:
        files: |
         packaging/opencv-4.7.0.zip
         packaging/opencv-js-4.7.0-emcc-3.1.26.zip
-        packaging/opencv-js-simd-4.7.0-emcc-3.1.26.zip
+        packaging/opencv-js-4.7.0-emcc-3.1.26-simd.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - run: sudo apt-get update && sudo apt install pcregrep libjpeg-dev ninja-build
     - run: ./build.sh linux
     - run: ./build.sh emscripten
-    - run: ./build.sh emscripten-simd
+    - run: ./build.sh --simd emscripten
     - run: echo "Done!"
     - uses: actions/upload-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,20 @@ Then, move on to the emscripten build:
 ## Pre-built binaries
 
 You don't need to build the libs you can grab from [Releases](https://github.com/webarkit/opencv-em/releases)
+
+## Use of pre-built binaries
+
+You can use FetchContent in a cmake project (CMakeLists.txt):
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  build_opencv
+ URL https://github.com/webarkit/opencv-em/releases/download/0.1.4/opencv-4.7.0.zip
+)
+
+FetchContent_MakeAvailable(build_opencv)
+```
+
+or you can use [curl](https://github.com/curl/curl) or [bootstrapping](https://github.com/corporateshark/bootstrapping) to download the package and make it available to your project.

--- a/build.sh
+++ b/build.sh
@@ -248,10 +248,10 @@ fi
 
 OPENCV_CPU_OPTIMIZATIONS="-DCPU_BASELINE="" -DCPU_DISPATCH="""
 OPENCV_DEFINES="-DENABLE_PIC=FALSE"
-OPENCV_EXCLUDE="-DBUILD_SHARED_LIBS=OFF -DBUILD_JAVA=OFF -DWITH_1394=OFF -DWITH_ADE=OFF -DWITH_VTK=OFF -DWITH_EIGEN=OFF -DWITH_FFMPEG=OFF -DWITH_GSTREAMER=OFF -DWITH_GTK=OFF -DWITH_GTK_2_X=OFF -DWITH_IPP=OFF -DWITH_JASPER=OFF -DWITH_JPEG=OFF -DWITH_WEBP=OFF -DWITH_OPENEXR=OFF -DWITH_OPENGL=OFF -DWITH_OPENVX=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PNG=OFF -DWITH_TBB=OFF -DWITH_TIFF=OFF -DWITH_V4L=OFF -DWITH_OPENCL=OFF -DWITH_OPENCL_SVM=OFF -DWITH_OPENCLAMDFFT=OFF -DWITH_OPENCLAMDBLAS=OFF -DWITH_GPHOTO2=OFF -DWITH_LAPACK=OFF -DWITH_ITT=OFF -DWITH_QUIRC=OFF -DCV_TRACE=OFF"
-OPENCV_INCLUDE="-DBUILD_OPENJPEG=ON -DWITH_JPEG=ON -DBUILD_ZLIB=ON"
-OPENCV_MODULES_EXCLUDE="-DBUILD_opencv_dnn=OFF -DBUILD_opencv_highgui=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_python3=OFF -DBUILD_opencv_shape=OFF -DBUILD_opencv_stitching=OFF -DBUILD_opencv_superres=OFF -DBUILD_opencv_videoio=OFF -DBUILD_opencv_videostab=OFF"
-OPENCV_MODULES_INCLUDE="-DBUILD_opencv_calib3d=ON -DBUILD_opencv_core=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_flann=ON -DBUILD_opencv_imgcodecs=ON -DBUILD_opencv_video=ON "
+OPENCV_EXCLUDE="-DBUILD_SHARED_LIBS=OFF -DBUILD_JAVA=OFF -DWITH_1394=OFF -DWITH_ADE=OFF -DWITH_VTK=OFF -DWITH_EIGEN=OFF -DWITH_GTK=OFF -DWITH_GTK_2_X=OFF -DWITH_IPP=OFF -DWITH_JASPER=OFF -DWITH_JPEG=OFF -DWITH_WEBP=OFF -DWITH_OPENEXR=OFF -DWITH_OPENGL=OFF -DWITH_OPENVX=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PNG=OFF -DWITH_TBB=OFF -DWITH_TIFF=OFF -DWITH_OPENCL=OFF -DWITH_OPENCL_SVM=OFF -DWITH_OPENCLAMDFFT=OFF -DWITH_OPENCLAMDBLAS=OFF -DWITH_GPHOTO2=OFF -DWITH_LAPACK=OFF -DWITH_ITT=OFF -DWITH_QUIRC=OFF -DCV_TRACE=OFF"
+OPENCV_INCLUDE="-DWITH_V4L=ON_-DWITH_FFMPEG=ON -DWITH_GSTREAMER=ON -DBUILD_OPENJPEG=ON -DWITH_JPEG=ON -DBUILD_ZLIB=ON"
+OPENCV_MODULES_EXCLUDE="-DBUILD_opencv_dnn=OFF -DBUILD_opencv_highgui=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_python3=OFF -DBUILD_opencv_shape=OFF -DBUILD_opencv_stitching=OFF -DBUILD_opencv_superres=OFF -DBUILD_opencv_videostab=OFF"
+OPENCV_MODULES_INCLUDE="-DBUILD_opencv_calib3d=ON -DBUILD_opencv_core=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_flann=ON -DBUILD_opencv_imgcodecs=ON -DBUILD_opencv_video=ON -DBUILD_opencv_videoio=ON "
 OPENCV_EXTRA_MODULES_EXCLUDE="-DBUILD_opencv_bgsegm=OFF -DBUILD_opencv_bioinspired=OFF -DBUILD_opencv_fuzzy=OFF -DBUILD_opencv_hfs=OFF -DBUILD_opencv_img_hash=OFF -DBUILD_opencv_intensity_transform=OFF -DBUILD_opencv_line_descriptor=OFF -DBUILD_opencv_optflow=OFF -DBUILD_opencv_phase_unwrapping=OFF -DBUILD_opencv_plot=OFF -DBUILD_opencv_rapid=OFF -DBUILD_opencv_reg=OFF -DBUILD_opencv_rgbd=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_stereo=OFF -DBUILD_opencv_structured_light=OFF -DBUILD_opencv_surface_matching=OFF -DBUILD_opencv_tracking=OFF -DBUILD_opencv_ximgproc=OFF -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_xphoto=OFF"
 OPENCV_EXTRA_MODULES_INCLUDE="-DBUILD_opencv_xfeatures2d=ON "
 OPENCV_EXTRA_MODULES_PATH=" -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules/xfeatures2d ../ "
@@ -331,6 +331,9 @@ cd ${OURDIR}
         fi
         rsync -ra -R libs/opencv/modules/imgproc/include ${TARGET_DIR}
         rsync -ra -R libs/opencv/modules/video/include ${TARGET_DIR}
+        if [ $BUILD_CMAKE ] ; then
+            rsync -ra -R libs/opencv/modules/videoio/include ${TARGET_DIR}
+        fi
         rsync -ra -R libs/opencv/include/opencv2 ${TARGET_DIR}
         rsync -ra -R libs/opencv_contrib/modules/xfeatures2d/include ${TARGET_DIR}
     fi


### PR DESCRIPTION
This PR add videio support to the build script and consequently after merged i will make a new release with the new libs.
Enabled plugins for V4L, ffmpeg and gstreamer. Without them you can't display a video.
No changes to the Emscripten build.
@Algomorph This PR also will integrate changes from #7 into the `main` branch.
I added a bunch of improves to the action github script to address some minor issues.